### PR TITLE
Bloodhound

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ $ trackingdog http://charcod.es/static/bundle-44.0449b572b5.js:4:22208
 http://charcod.es/js/app.js:95:0
 ```
 
+Note that it is also possible to pipe a full stack trace over stdin:
+
+```sh
+$ pbpaste | trackingdog # paste from clipboard (macos only)
+$ trackingdog < myStacktraceFile.txt # pipe in a file
+```
+
 You can map local folders in as workspaces (à la Chrome Dev Tools) and have
 the remote files mapped to paths local to your filesystem:
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ $ trackingdog http://charcod.es/static/bundle-44.0449b572b5.js:4:22208
 http://charcod.es/js/app.js:95:0
 ```
 
+You can map local folders in as workspaces (à la Chrome Dev Tools) and have
+the remote files mapped to paths local to your filesystem:
+
+```sh
+$ trackingdog --workspace http://charcod.es/js=./src http://charcod.es/static/bundle-44.0449b572b5.js:4:22208
+./src/app.js:95:0
+```
+
 If the referenced source file can be retrieved, you'll get a bit of context:
 
 ```js
@@ -74,4 +82,3 @@ console.log(`Yay, the location in the original source is ${url}:${line}:${column
 * Recursively attempt to load the source file and see if it also has a source
   map reference (in case someone used a "dist" file in a bundle without using
   source-map-loader or equivalent)
-* Support a local "workspace" directory à la Chrome Dev Tools

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,10 @@ const pathModule = require('path');
 const getStdin = require('get-stdin');
 const errorStackParser = require('error-stack-parser');
 
+const fs = require('fs');
+const { promisify } = require('util');
+const readFile = promisify(fs.readFile);
+
 const argv = require('yargs')
   .usage('$0 [--root <dir>] [--[no-]context] <url>:<line>:<column>')
   .option('root', {
@@ -144,30 +148,36 @@ async function handleStdIn(argv) {
       );
     }
 
-    let { url, sourceAsset, sourceText, line, column } = firstFrame;
+    if (context) {
+      let { url } = firstFrame;
 
-    if (/^file:/.test(url)) {
-      url = pathModule.relative(process.cwd(), urlTools.fileUrlToFsPath(url));
-    }
+      if (/^file:/.test(url)) {
+        url = pathModule.relative(process.cwd(), urlTools.fileUrlToFsPath(url));
+      } else if (/^https?:/.test(url)) {
+        let { pathname } = urlTools.parse(url);
 
-    if (context && (sourceAsset || sourceText)) {
-      if (typeof sourceText === 'undefined') {
-        await sourceAsset.load();
-        sourceText = sourceAsset.text;
+        if (pathname) {
+          url = pathModule.relative(process.cwd(), pathname.slice(1));
+        }
       }
 
       try {
         const snippetWithContext = renderSnippetWithContext({
-          sourceText,
-          contentType: sourceAsset
-            ? sourceAsset.contentType
-            : pathModule.extname(url.replace(/[?#].*$/, '')),
-          line,
-          column
+          sourceText: await readFile(url, 'utf-8'),
+          contentType: 'application/javascript',
+          line: firstFrame.line,
+          column: firstFrame.column
         });
 
         console.log(snippetWithContext + '\n');
-      } catch (e) {}
+      } catch (e) {
+        if (e.code === 'ENOENT') {
+          // file does not exist on disk.
+          console.error("Could not find file '%s' on disk.", url);
+        } else {
+          throw e;
+        }
+      }
     }
 
     console.log(result);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,10 @@ const pathModule = require('path');
 const getStdin = require('get-stdin');
 const errorStackParser = require('error-stack-parser');
 
+const fs = require('fs');
+const { promisify } = require('util');
+const readFile = promisify(fs.readFile);
+
 const argv = require('yargs')
   .usage('$0 [--root <dir>] [--[no-]context] <url>:<line>:<column>')
   .option('root', {
@@ -107,16 +111,13 @@ async function handleNonOptionArguments(argv) {
 }
 
 async function handleStdIn(argv) {
-  // TODO: We cannot honor the argv.context option in stdin mode. It would be
-  //       nice to issue a warning when the flag is passed in, but I cannot tell
-  //       wether the context is set by default or if it's been set explicitly.
-
-  const { root } = argv;
+  const { root, context } = argv;
 
   const stdin = await getStdin();
   const trackingDog = new TrackingDog({ root });
   const frames = errorStackParser.parse({ stack: stdin });
   let result = stdin;
+  let firstFrame;
 
   try {
     for (const {
@@ -136,11 +137,47 @@ async function handleStdIn(argv) {
         column: parseInt(columnNumber)
       });
 
+      if (!firstFrame) {
+        firstFrame = res;
+      }
+
       // TODO: Fix formatting of the reoutputted stacktrace.
       result = result.replace(
         source,
         `  at ${functionName || ''} (${res.url}:${res.line}:${res.column})`
       );
+    }
+
+    if (context) {
+      let { url } = firstFrame;
+
+      if (/^file:/.test(url)) {
+        url = pathModule.relative(process.cwd(), urlTools.fileUrlToFsPath(url));
+      } else if (/^https?:/.test(url)) {
+        let { pathname } = urlTools.parse(url);
+
+        if (pathname) {
+          url = pathModule.relative(process.cwd(), pathname.slice(1));
+        }
+      }
+
+      try {
+        const snippetWithContext = renderSnippetWithContext({
+          sourceText: await readFile(url, 'utf-8'),
+          contentType: 'application/javascript',
+          line: firstFrame.line,
+          column: firstFrame.column
+        });
+
+        console.log(snippetWithContext + '\n');
+      } catch (e) {
+        if (e.code === 'ENOENT') {
+          // file does not exist on disk.
+          console.error("Could not find file '%s' on disk.", url);
+        } else {
+          throw e;
+        }
+      }
     }
 
     console.log(result);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -36,7 +36,7 @@ function getWorkspaceMappings(workspaces) {
 function applyWorkspaceMappings(url, workspaceMappings) {
   for (const [from, to] of Object.entries(workspaceMappings)) {
     // from is a prefix match
-    if (url.substr(0, from.length) === from) {
+    if (url.startsWith(from)) {
       return pathModule.join(to, url.substr(from.length));
     }
   }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,7 +5,7 @@ const MagicPen = require('magicpen');
 const urlTools = require('urltools');
 const pathModule = require('path');
 
-const { root, context, _: nonOptionArgs } = require('yargs')
+const argv = require('yargs')
   .usage('$0 [--root <dir>] [--[no-]context] <url>:<line>:<column>')
   .option('root', {
     demand: false,
@@ -16,8 +16,7 @@ const { root, context, _: nonOptionArgs } = require('yargs')
     demand: false,
     default: process.stdout.isTTY,
     type: 'boolean'
-  })
-  .demand(1).argv;
+  }).argv;
 
 function renderSnippetWithContext({ sourceText, contentType, line, column }) {
   const sourceLines = sourceText.split(/\n\r?|\r\n?/);
@@ -41,7 +40,9 @@ function renderSnippetWithContext({ sourceText, contentType, line, column }) {
   return magicPen.toString(MagicPen.defaultFormat);
 }
 
-(async () => {
+async function handleNonOptionArguments(argv) {
+  const { root, context, _: nonOptionArgs } = argv;
+
   for (let i = 0; i < nonOptionArgs.length; i += 1) {
     let urlWithLineAndColumn = nonOptionArgs[i];
     while (
@@ -100,5 +101,14 @@ function renderSnippetWithContext({ sourceText, contentType, line, column }) {
       console.error(err.stack);
       process.exit(1);
     }
+  }
+}
+
+(async () => {
+  if (argv._.length > 0) {
+    await handleNonOptionArguments(argv);
+  } else {
+    console.error('NYI: Passing in a stack trace through stdin.');
+    process.exit(1);
   }
 })();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,9 +11,48 @@ const fs = require('fs');
 const { promisify } = require('util');
 const readFile = promisify(fs.readFile);
 
+function getWorkspaceMappings(workspaces) {
+  if (typeof workspaces === 'string') {
+    workspaces = [workspaces];
+  } else if (!workspaces) {
+    return {};
+  }
+
+  const mappings = {};
+
+  for (const pair of workspaces) {
+    const [from, to] = pair.split('=');
+
+    if (!from || !to) {
+      throw new Error(`Invalid workspace mapping "${pair}"`);
+    }
+
+    mappings[from] = to;
+  }
+
+  return mappings;
+}
+
+function applyWorkspaceMappings(url, workspaceMappings) {
+  for (const [from, to] of Object.entries(workspaceMappings)) {
+    // from is a prefix match
+    if (url.substr(0, from.length) === from) {
+      return pathModule.join(to, url.substr(from.length));
+    }
+  }
+
+  return url;
+}
+
 const argv = require('yargs')
-  .usage('$0 [--root <dir>] [--[no-]context] <url>:<line>:<column>')
+  .usage(
+    '$0 [--root <dir>] [--[no-]context] [--workspace http://example.com=../example] <url>:<line>:<column>'
+  )
   .option('root', {
+    demand: false,
+    type: 'string'
+  })
+  .option('workspace', {
     demand: false,
     type: 'string'
   })
@@ -47,7 +86,8 @@ function renderSnippetWithContext({ sourceText, contentType, line, column }) {
 }
 
 async function handleNonOptionArguments(argv) {
-  const { root, context, _: nonOptionArgs } = argv;
+  const { root, context, workspace, _: nonOptionArgs } = argv;
+  const workspaceMappings = getWorkspaceMappings(workspace);
 
   for (let i = 0; i < nonOptionArgs.length; i += 1) {
     let urlWithLineAndColumn = nonOptionArgs[i];
@@ -83,25 +123,43 @@ async function handleNonOptionArguments(argv) {
       if (/^file:/.test(url)) {
         url = pathModule.relative(process.cwd(), urlTools.fileUrlToFsPath(url));
       }
+
+      url = applyWorkspaceMappings(url, workspaceMappings);
+
       console.log(`${url}:${line}:${column}`);
 
-      if (context && (sourceAsset || sourceText)) {
-        try {
-          if (typeof sourceText === 'undefined') {
+      if (context) {
+        let contentType = sourceAsset
+          ? sourceAsset.contentType
+          : pathModule.extname(url.replace(/[?#].*$/, ''));
+
+        if (!sourceText && !/^(http|https|file):/.test(url)) {
+          try {
+            const localUrl = pathModule.relative(process.cwd(), url);
+            sourceText = await readFile(localUrl, 'utf-8');
+            contentType =
+              pathModule.extname(localUrl) === '.js'
+                ? 'application/javascript'
+                : contentType;
+          } catch (e) {}
+        } else if (!sourceText && sourceAsset) {
+          try {
             await sourceAsset.load();
             sourceText = sourceAsset.text;
-          }
+            contentType = sourceAsset.contentType;
+          } catch (e) {}
+        }
+
+        if (sourceText) {
           console.log(
             renderSnippetWithContext({
               sourceText,
-              contentType: sourceAsset
-                ? sourceAsset.contentType
-                : pathModule.extname(url.replace(/[?#].*$/, '')),
+              contentType,
               line,
               column
             })
           );
-        } catch (err) {}
+        }
       }
     } catch (err) {
       console.error(err.stack);
@@ -111,7 +169,8 @@ async function handleNonOptionArguments(argv) {
 }
 
 async function handleStdIn(argv) {
-  const { root, context } = argv;
+  const { root, context, workspace } = argv;
+  const workspaceMappings = getWorkspaceMappings(workspace);
 
   const stdin = await getStdin();
   const trackingDog = new TrackingDog({ root });
@@ -141,42 +200,49 @@ async function handleStdIn(argv) {
         firstFrame = res;
       }
 
+      let url = applyWorkspaceMappings(res.url, workspaceMappings);
+
       // TODO: Fix formatting of the reoutputted stacktrace.
       result = result.replace(
         source,
-        `  at ${functionName || ''} (${res.url}:${res.line}:${res.column})`
+        `  at ${functionName || ''} (${url}:${res.line}:${res.column})`
       );
     }
 
     if (context) {
-      let { url } = firstFrame;
+      let { url, sourceText, sourceAsset, line, column } = firstFrame;
+      let contentType = sourceAsset
+        ? sourceAsset.contentType
+        : pathModule.extname(url.replace(/[?#].*$/, ''));
 
-      if (/^file:/.test(url)) {
-        url = pathModule.relative(process.cwd(), urlTools.fileUrlToFsPath(url));
-      } else if (/^https?:/.test(url)) {
-        let { pathname } = urlTools.parse(url);
+      url = applyWorkspaceMappings(url, workspaceMappings);
 
-        if (pathname) {
-          url = pathModule.relative(process.cwd(), pathname.slice(1));
-        }
+      if (!sourceText && !/^(http|https|file):/.test(url)) {
+        try {
+          const localUrl = pathModule.relative(process.cwd(), url);
+          sourceText = await readFile(localUrl, 'utf-8');
+          contentType =
+            pathModule.extname(localUrl) === '.js'
+              ? 'application/javascript'
+              : contentType;
+        } catch (e) {}
+      } else if (!sourceText && sourceAsset) {
+        try {
+          await sourceAsset.load();
+          sourceText = sourceAsset.text;
+          contentType = sourceAsset.contentType;
+        } catch (e) {}
       }
 
-      try {
-        const snippetWithContext = renderSnippetWithContext({
-          sourceText: await readFile(url, 'utf-8'),
-          contentType: 'application/javascript',
-          line: firstFrame.line,
-          column: firstFrame.column
-        });
-
-        console.log(snippetWithContext + '\n');
-      } catch (e) {
-        if (e.code === 'ENOENT') {
-          // file does not exist on disk.
-          console.error("Could not find file '%s' on disk.", url);
-        } else {
-          throw e;
-        }
+      if (sourceText) {
+        console.log(
+          renderSnippetWithContext({
+            sourceText,
+            contentType,
+            line,
+            column
+          })
+        );
       }
     }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,6 +4,8 @@ const TrackingDog = require('./TrackingDog');
 const MagicPen = require('magicpen');
 const urlTools = require('urltools');
 const pathModule = require('path');
+const getStdin = require('get-stdin');
+const errorStackParser = require('error-stack-parser');
 
 const argv = require('yargs')
   .usage('$0 [--root <dir>] [--[no-]context] <url>:<line>:<column>')
@@ -104,11 +106,54 @@ async function handleNonOptionArguments(argv) {
   }
 }
 
+async function handleStdIn(argv) {
+  // TODO: We cannot honor the argv.context option in stdin mode. It would be
+  //       nice to issue a warning when the flag is passed in, but I cannot tell
+  //       wether the context is set by default or if it's been set explicitly.
+
+  const { root } = argv;
+
+  const stdin = await getStdin();
+  const trackingDog = new TrackingDog({ root });
+  const frames = errorStackParser.parse({ stack: stdin });
+  let result = stdin;
+
+  try {
+    for (const {
+      lineNumber,
+      columnNumber,
+      fileName,
+      source,
+      functionName
+    } of frames) {
+      if (!/^https?:/.test(fileName)) {
+        break;
+      }
+
+      const res = await trackingDog.track({
+        url: fileName,
+        line: parseInt(lineNumber),
+        column: parseInt(columnNumber)
+      });
+
+      // TODO: Fix formatting of the reoutputted stacktrace.
+      result = result.replace(
+        source,
+        `  at ${functionName || ''} (${res.url}:${res.line}:${res.column})`
+      );
+    }
+
+    console.log(result);
+  } catch (err) {
+    console.error(err.stack);
+    process.exit(1);
+  }
+}
+
 (async () => {
   if (argv._.length > 0) {
     await handleNonOptionArguments(argv);
   } else {
-    console.error('NYI: Passing in a stack trace through stdin.');
-    process.exit(1);
+    await handleStdIn(argv);
   }
 })();

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,10 +7,6 @@ const pathModule = require('path');
 const getStdin = require('get-stdin');
 const errorStackParser = require('error-stack-parser');
 
-const fs = require('fs');
-const { promisify } = require('util');
-const readFile = promisify(fs.readFile);
-
 const argv = require('yargs')
   .usage('$0 [--root <dir>] [--[no-]context] <url>:<line>:<column>')
   .option('root', {
@@ -148,36 +144,30 @@ async function handleStdIn(argv) {
       );
     }
 
-    if (context) {
-      let { url } = firstFrame;
+    let { url, sourceAsset, sourceText, line, column } = firstFrame;
 
-      if (/^file:/.test(url)) {
-        url = pathModule.relative(process.cwd(), urlTools.fileUrlToFsPath(url));
-      } else if (/^https?:/.test(url)) {
-        let { pathname } = urlTools.parse(url);
+    if (/^file:/.test(url)) {
+      url = pathModule.relative(process.cwd(), urlTools.fileUrlToFsPath(url));
+    }
 
-        if (pathname) {
-          url = pathModule.relative(process.cwd(), pathname.slice(1));
-        }
+    if (context && (sourceAsset || sourceText)) {
+      if (typeof sourceText === 'undefined') {
+        await sourceAsset.load();
+        sourceText = sourceAsset.text;
       }
 
       try {
         const snippetWithContext = renderSnippetWithContext({
-          sourceText: await readFile(url, 'utf-8'),
-          contentType: 'application/javascript',
-          line: firstFrame.line,
-          column: firstFrame.column
+          sourceText,
+          contentType: sourceAsset
+            ? sourceAsset.contentType
+            : pathModule.extname(url.replace(/[?#].*$/, '')),
+          line,
+          column
         });
 
         console.log(snippetWithContext + '\n');
-      } catch (e) {
-        if (e.code === 'ENOENT') {
-          // file does not exist on disk.
-          console.error("Could not find file '%s' on disk.", url);
-        } else {
-          throw e;
-        }
-      }
+      } catch (e) {}
     }
 
     console.log(result);

--- a/lib/cli.spec.js
+++ b/lib/cli.spec.js
@@ -3,15 +3,17 @@ const pathModule = require('path');
 const expect = require('unexpected').clone();
 
 expect.addAssertion(
-  '<array> to yield output <string>',
-  async (expect, args, expectedOutput) => {
+  '<object> to yield output <string>',
+  async (expect, subject, expectedOutput) => {
+    const { args = [], stdin } = subject;
+
     let stdout;
     let stderr;
     try {
-      [stdout, stderr] = await run([
-        pathModule.resolve(__dirname, 'cli.js'),
-        ...args
-      ]);
+      [stdout, stderr] = await run(
+        [pathModule.resolve(__dirname, 'cli.js'), ...args],
+        stdin
+      );
     } catch (err) {
       if (err.stderr) {
         expect.fail(
@@ -25,6 +27,13 @@ expect.addAssertion(
     expect(stderr, 'when decoded as', 'utf-8', 'to equal', '');
 
     expect(stdout, 'when decoded as', 'utf-8', 'to equal', expectedOutput);
+  }
+);
+
+expect.addAssertion(
+  '<array> to yield output <string>',
+  async (expect, args, expectedOutput) => {
+    return expect({ args }, 'to yield output', expectedOutput);
   }
 );
 

--- a/lib/cli.spec.js
+++ b/lib/cli.spec.js
@@ -132,4 +132,31 @@ describe('cli', function() {
       );
     });
   });
+
+  describe('while passing a stack trace on stdin', () => {
+    it('should output a sourcemapped stacktrace', async () => {
+      await expect(
+        {
+          stdin:
+            'ApiError: Closed\n' +
+            '  at e.<anonymous> (https://mail-static.cdn-one.com/bundle.webmail-touch.3d9ac5fef9.js:222:87367)\n' +
+            '  at M (https://mail-static.cdn-one.com/bundle.webmail-touch.3d9ac5fef9.js:165:334825)\n' +
+            '  at Generator.c._invoke (https://mail-static.cdn-one.com/bundle.webmail-touch.3d9ac5fef9.js:165:334620)\n' +
+            '  at Generator.e.(anonymous function) [as next] (https://mail-static.cdn-one.com/bundle.webmail-touch.3d9ac5fef9.js:165:335004)\n' +
+            '  at r (https://mail-static.cdn-one.com/bundle.webmail-touch.3d9ac5fef9.js:222:67968)\n' +
+            '  at https://mail-static.cdn-one.com/bundle.webmail-touch.3d9ac5fef9.js:222:68062\n' +
+            '  at <anonymous>\n'
+        },
+        'to yield output',
+        'ApiError: Closed\n' +
+          '  at e.<anonymous> (https://mail-static.cdn-one.com/src/common/lib/Api.js:734:18)\n' +
+          '  at M (https://mail-static.cdn-one.com/node_modules/regenerator-runtime/runtime.js:114:0)\n' +
+          '  at Generator.c._invoke (https://mail-static.cdn-one.com/node_modules/regenerator-runtime/runtime.js:324:0)\n' +
+          '  at Generator.e.(anonymous function) [as next] (https://mail-static.cdn-one.com/node_modules/regenerator-runtime/runtime.js:162:0)\n' +
+          '  at r (https://mail-static.cdn-one.com/package.json:2:26)\n' +
+          '  at  (https://mail-static.cdn-one.com/package.json:2:26)\n' +
+          '  at <anonymous>\n\n'
+      );
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "license": "BSD-3-Clause",
   "dependencies": {
     "assetgraph": "^4.0.0",
+    "error-stack-parser": "^2.0.1",
+    "get-stdin": "^5.0.1",
     "magicpen": "^5.12.0",
     "magicpen-prism": "^2.3.0",
     "urltools": "^0.3.5",


### PR DESCRIPTION
Take two :-) Replaces #1  

There's still a few things we should look at before this is ready to land.

There's a few todo comments in the code:
1. Regarding the --context switch - it doesn't really make sense to use that while passing a stacktrace on stdin. I don't know how to arrange that... Maybe we put the stdin functionality behind a switch `-i` and make them mutually exclusive and default `context` to true when stdin mode is not active.
2. Formatting non chrome-like stack traces is currently broken. It should probably try to retain the format of what it is passed.