### PR TITLE
WIP: Support inverse mapping from a source file to a generated file

### DIFF
--- a/lib/TrackingDog.js
+++ b/lib/TrackingDog.js
@@ -5,7 +5,7 @@ class TrackingDog {
     this.assetGraph = assetGraph || new AssetGraph({ root });
   }
 
-  async track({ url, line, column }) {
+  async track({ url, line, column, inverse }) {
     let asset = this.assetGraph.addAsset(url);
     await asset.load();
 
@@ -27,53 +27,70 @@ class TrackingDog {
     } else {
       throw new Error('No source map found');
     }
+    if (inverse) {
+      // The source-map library does some internal normalization that necessitates this:
+      inverse = inverse.replace(/^webpack:\/\/\/\.\//, 'webpack:///');
 
-    const originalPosition = sourceMap.originalPositionFor({
-      line,
-      column
-    });
-
-    if (originalPosition && originalPosition.source) {
-      originalPosition.url = this.assetGraph.resolveUrl(
-        sourceMap.url,
-        originalPosition.source
+      const generatedPosition = sourceMap.generatedPositionFor({
+        source: inverse,
+        line,
+        column
+      });
+      generatedPosition.url = this.assetGraph.resolveUrl(
+        sourceMap.nonInlineAncestor.url,
+        sourceMap.parseTree.file
       );
-      if (
-        Array.isArray(sourceMap.parseTree.sources) &&
-        Array.isArray(sourceMap.parseTree.sourcesContent)
-      ) {
-        let sourcesIndex = sourceMap.parseTree.sources.indexOf(
+      generatedPosition.sourceAsset = this.assetGraph.addAsset(
+        generatedPosition.url
+      );
+      return generatedPosition;
+    } else {
+      const originalPosition = sourceMap.originalPositionFor({
+        line,
+        column
+      });
+      if (originalPosition && originalPosition.source) {
+        originalPosition.url = this.assetGraph.resolveUrl(
+          sourceMap.url,
           originalPosition.source
         );
-        if (sourcesIndex === -1) {
-          // Try a workaround for a weird webpackism:
-          sourcesIndex = sourceMap.parseTree.sources.indexOf(
-            originalPosition.source.replace(/^webpack:\/\/\//, 'webpack:///./')
-          );
-        }
-        if (sourcesIndex === -1) {
-          // Try a workaround for another weird webpackism:
-          sourcesIndex = sourceMap.parseTree.sources.indexOf(
-            originalPosition.source.replace(/^webpack:\/\/\//, 'webpack:////')
-          );
-        }
         if (
-          sourcesIndex !== -1 &&
-          sourcesIndex < sourceMap.parseTree.sourcesContent.length
+          Array.isArray(sourceMap.parseTree.sources) &&
+          Array.isArray(sourceMap.parseTree.sourcesContent)
         ) {
-          originalPosition.sourceText =
-            sourceMap.parseTree.sourcesContent[sourcesIndex];
+          let sourcesIndex = sourceMap.parseTree.sources.indexOf(
+            originalPosition.source
+          );
+          if (sourcesIndex === -1) {
+            // Try a workaround for a weird webpackism:
+            sourcesIndex = sourceMap.parseTree.sources.indexOf(
+              originalPosition.source.replace(
+                /^webpack:\/\/\//,
+                'webpack:///./'
+              )
+            );
+          }
+          if (sourcesIndex === -1) {
+            // Try a workaround for another weird webpackism:
+            sourcesIndex = sourceMap.parseTree.sources.indexOf(
+              originalPosition.source.replace(/^webpack:\/\/\//, 'webpack:////')
+            );
+          }
+          if (
+            sourcesIndex !== -1 &&
+            sourcesIndex < sourceMap.parseTree.sourcesContent.length
+          ) {
+            originalPosition.sourceText =
+              sourceMap.parseTree.sourcesContent[sourcesIndex];
+          }
         }
+        originalPosition.sourceAsset = this.assetGraph.addAsset(
+          originalPosition.url
+        );
+        return originalPosition;
       }
-      originalPosition.sourceAsset = this.assetGraph.addAsset(
-        originalPosition.url
-      );
-      return originalPosition;
-    } else {
-      throw new Error(
-        `No source mapping available for ${url}:${line}:${column}`
-      );
     }
+    throw new Error(`No source mapping available for ${url}:${line}:${column}`);
   }
 }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -56,6 +56,10 @@ const argv = require('yargs')
     demand: false,
     type: 'string'
   })
+  .option('inverse', {
+    demand: false,
+    type: 'string'
+  })
   .option('context', {
     alias: 'c',
     demand: false,
@@ -86,7 +90,7 @@ function renderSnippetWithContext({ sourceText, contentType, line, column }) {
 }
 
 async function handleNonOptionArguments(argv) {
-  const { root, context, workspace, _: nonOptionArgs } = argv;
+  const { root, context, workspace, _: nonOptionArgs, inverse } = argv;
   const workspaceMappings = getWorkspaceMappings(workspace);
 
   for (let i = 0; i < nonOptionArgs.length; i += 1) {
@@ -117,7 +121,8 @@ async function handleNonOptionArguments(argv) {
       } = await trackingDog.track({
         column: parseInt(tokens.pop(), 10),
         line: parseInt(tokens.pop(), 10),
-        url: tokens.join(':')
+        url: tokens.join(':'),
+        inverse
       });
 
       if (/^file:/.test(url)) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -174,7 +174,7 @@ async function handleNonOptionArguments(argv) {
 }
 
 async function handleStdIn(argv) {
-  const { root, context, workspace } = argv;
+  const { root, context, workspace, inverse } = argv;
   const workspaceMappings = getWorkspaceMappings(workspace);
 
   const stdin = await getStdin();
@@ -198,7 +198,8 @@ async function handleStdIn(argv) {
       const res = await trackingDog.track({
         url: fileName,
         line: parseInt(lineNumber),
-        column: parseInt(columnNumber)
+        column: parseInt(columnNumber),
+        inverse
       });
 
       if (!firstFrame) {

--- a/lib/cli.spec.js
+++ b/lib/cli.spec.js
@@ -134,6 +134,30 @@ describe('cli', function() {
     });
   });
 
+  describe('in --inverse mode', function() {
+    it('should map a location in an original file to the right place in a corresponding generated one', async function() {
+      await expect(
+        [
+          '--no-context',
+          pathModule.relative(
+            process.cwd(),
+            pathModule.resolve(
+              __dirname,
+              '..',
+              'testdata',
+              'existingJavaScriptSourceMap',
+              'jquery-1.10.1.min.js'
+            )
+          ) + ':109:16',
+          '--inverse',
+          'jquery-1.10.1.js'
+        ],
+        'to yield output',
+        'testdata/existingJavaScriptSourceMap/jquery-1.10.1.min.js:4:741\n'
+      );
+    });
+  });
+
   describe('while passing a stack trace on stdin', () => {
     it('should output a sourcemapped stacktrace', async () => {
       await expect(

--- a/lib/cli.spec.js
+++ b/lib/cli.spec.js
@@ -183,5 +183,32 @@ describe('cli', function() {
           '  at <anonymous>\n\n'
       );
     });
+
+    describe('in --inverse mode', function() {
+      it('should output a stacktrace with the locations in the generated files', async function() {
+        await expect(
+          {
+            args: ['--no-context', '--inverse', 'jquery-1.10.1.js'],
+            stdin:
+              'ApiError: Closed\n' +
+              '  at something (' +
+              pathModule.relative(
+                process.cwd(),
+                pathModule.resolve(
+                  __dirname,
+                  '..',
+                  'testdata',
+                  'existingJavaScriptSourceMap',
+                  'jquery-1.10.1.js'
+                )
+              ) +
+              ':109:16)\n'
+          },
+          'to yield output',
+          'ApiError: Closed\n' +
+            'testdata/existingJavaScriptSourceMap/jquery-1.10.1.min.js:4:741\n'
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
Implements support for:

```
trackingdog https://d33d1hg6rmga0k.cloudfront.net/uploaded/bundle-survey-86a4f8360e9837314dde.js:184:26 --inverse webpack:///./containers/Question/index.js
https://d33d1hg6rmga0k.cloudfront.net/uploaded/bundle-survey-86a4f8360e9837314dde.js:1:131600
```

Needs a bit of cleanup and the `:line:column` should really go on the source file so it'd be:

```
trackingdog https://d33d1hg6rmga0k.cloudfront.net/uploaded/bundle-survey-86a4f8360e9837314dde.js --inverse webpack:///./containers/Question/index.js:184:26
```

Could also be cool to support a mode where an HTML url could be entered, and then trackingdog would populate the graph and find all generated files that contain the given line/column of the source file. In most cases that would probably be just one :)

TODO:

- [ ] Move :line:column to the `--inverse` arg
- [ ] Default `--context` to off in this mode (or find a way to render a snippet of a line, as generated files run very long)
- [ ] Test inverse mapping of a complete stack trace