### PR TITLE
Pass in cwd from cli.js to main.js

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 require('@gustavnikolaj/async-main-wrap')(require('./main'))(
+  process.cwd(),
   process.argv.slice(2),
   console,
   require('get-stdin'),

--- a/lib/main.js
+++ b/lib/main.js
@@ -62,7 +62,7 @@ function renderSnippetWithContext({ sourceText, contentType, line, column }) {
   return magicPen.toString(MagicPen.defaultFormat);
 }
 
-module.exports = async (argv, console, getStdin, isTTY) => {
+module.exports = async (cwd, argv, console, getStdin, isTTY) => {
   const commandLineOptions = require('yargs')(argv)
     .usage(
       '$0 [--root <dir>] [--[no-]context] [--workspace http://example.com=../example] <url>:<line>:<column>'
@@ -82,7 +82,7 @@ module.exports = async (argv, console, getStdin, isTTY) => {
       type: 'boolean'
     }).argv;
 
-  async function handleNonOptionArguments(argv) {
+  async function handleNonOptionArguments(cwd, argv) {
     const { root, context, workspace, _: nonOptionArgs } = argv;
     const workspaceMappings = getWorkspaceMappings(workspace);
 
@@ -118,7 +118,7 @@ module.exports = async (argv, console, getStdin, isTTY) => {
       });
 
       if (/^file:/.test(url)) {
-        url = pathModule.relative(process.cwd(), urlTools.fileUrlToFsPath(url));
+        url = pathModule.relative(cwd, urlTools.fileUrlToFsPath(url));
       }
 
       url = applyWorkspaceMappings(url, workspaceMappings);
@@ -132,7 +132,7 @@ module.exports = async (argv, console, getStdin, isTTY) => {
 
         if (!sourceText && !/^(http|https|file):/.test(url)) {
           try {
-            const localUrl = pathModule.relative(process.cwd(), url);
+            const localUrl = pathModule.relative(cwd, url);
             sourceText = await readFile(localUrl, 'utf-8');
             contentType =
               pathModule.extname(localUrl) === '.js'
@@ -161,7 +161,7 @@ module.exports = async (argv, console, getStdin, isTTY) => {
     }
   }
 
-  async function handleStdIn(argv) {
+  async function handleStdIn(cwd, argv) {
     const { root, context, workspace } = argv;
     const workspaceMappings = getWorkspaceMappings(workspace);
 
@@ -211,7 +211,7 @@ module.exports = async (argv, console, getStdin, isTTY) => {
 
       if (!sourceText && !/^(http|https|file):/.test(url)) {
         try {
-          const localUrl = pathModule.relative(process.cwd(), url);
+          const localUrl = pathModule.relative(cwd, url);
           sourceText = await readFile(localUrl, 'utf-8');
           contentType =
             pathModule.extname(localUrl) === '.js'
@@ -242,8 +242,8 @@ module.exports = async (argv, console, getStdin, isTTY) => {
   }
 
   if (commandLineOptions._.length > 0) {
-    await handleNonOptionArguments(commandLineOptions);
+    await handleNonOptionArguments(cwd, commandLineOptions);
   } else {
-    await handleStdIn(commandLineOptions);
+    await handleStdIn(cwd, commandLineOptions);
   }
 };

--- a/lib/main.spec.js
+++ b/lib/main.spec.js
@@ -23,7 +23,8 @@ describe('main', function() {
       if (!Array.isArray(output)) {
         output = [output];
       }
-      await main(switches, mockConsole, async () => stdin);
+      const cwd = pathModule.resolve(__dirname, '..');
+      await main(cwd, switches, mockConsole, async () => stdin);
       expect(mockConsole.log, 'to have calls satisfying', () => {
         for (const str of output) {
           mockConsole.log(str);
@@ -34,18 +35,7 @@ describe('main', function() {
 
   it('should output the mapped source location', async function() {
     await expect(
-      [
-        pathModule.relative(
-          process.cwd(),
-          pathModule.resolve(
-            __dirname,
-            '..',
-            'testdata',
-            'existingJavaScriptSourceMap',
-            'jquery-1.10.1.min.js'
-          )
-        ) + ':4:19'
-      ],
+      ['testdata/existingJavaScriptSourceMap/jquery-1.10.1.min.js:4:19'],
       'to yield output',
       'testdata/existingJavaScriptSourceMap/jquery-1.10.1.js:23:1'
     );
@@ -53,20 +43,7 @@ describe('main', function() {
 
   it('should support passing the line and column numbers as separate arguments', async function() {
     await expect(
-      [
-        pathModule.relative(
-          process.cwd(),
-          pathModule.resolve(
-            __dirname,
-            '..',
-            'testdata',
-            'existingJavaScriptSourceMap',
-            'jquery-1.10.1.min.js'
-          )
-        ),
-        '4',
-        '19'
-      ],
+      ['testdata/existingJavaScriptSourceMap/jquery-1.10.1.min.js', '4', '19'],
       'to yield output',
       'testdata/existingJavaScriptSourceMap/jquery-1.10.1.js:23:1'
     );
@@ -74,20 +51,7 @@ describe('main', function() {
 
   it('should support passing line:column as a separate argument', async function() {
     await expect(
-      [
-        pathModule.relative(
-          process.cwd(),
-          pathModule.resolve(
-            __dirname,
-            '..',
-            'testdata',
-            'existingJavaScriptSourceMap',
-            'jquery-1.10.1.min.js'
-          )
-        ),
-        '4',
-        '19'
-      ],
+      ['testdata/existingJavaScriptSourceMap/jquery-1.10.1.min.js', '4:19'],
       'to yield output',
       'testdata/existingJavaScriptSourceMap/jquery-1.10.1.js:23:1'
     );
@@ -98,16 +62,7 @@ describe('main', function() {
       await expect(
         [
           '--context',
-          pathModule.relative(
-            process.cwd(),
-            pathModule.resolve(
-              __dirname,
-              '..',
-              'testdata',
-              'existingJavaScriptSourceMap',
-              'jquery-1.10.1.min.js'
-            )
-          ),
+          'testdata/existingJavaScriptSourceMap/jquery-1.10.1.min.js',
           '4',
           '745'
         ],


### PR DESCRIPTION
Just a quick suggestion after looking at #14 

Passing through the current working directory along with the args to make sure that we have the context necessary to understand the relative paths in the args.

In the tests I updated the assertion to always set the cwd to the project root. This will probably never have too much impact out side of the tests, but at least it simplified those a bit :-)