### PR TITLE
Allow specifying the number of context lines via -A/--after-context -B/--before-context and -U/-C

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -40,13 +40,20 @@ function applyWorkspaceMappings(url, workspaceMappings) {
   return url;
 }
 
-function renderSnippetWithContext({ sourceText, contentType, line, column }) {
+function renderSnippetWithContext({
+  sourceText,
+  contentType,
+  line,
+  column,
+  beforeContext,
+  afterContext
+}) {
   const sourceLines = sourceText.split(/\n\r?|\r\n?/);
 
   const magicPen = new MagicPen()
     .use(require('magicpen-prism'))
     .code(
-      sourceLines.slice(Math.max(0, line - 6), line).join('\n'),
+      sourceLines.slice(Math.max(0, line - beforeContext - 1), line).join('\n'),
       contentType
     )
     .nl()
@@ -56,7 +63,10 @@ function renderSnippetWithContext({ sourceText, contentType, line, column }) {
   if (sourceLines.length >= line) {
     magicPen
       .nl()
-      .code(sourceLines.slice(line, line + 3).join('\n'), contentType);
+      .code(
+        sourceLines.slice(line, line + afterContext).join('\n'),
+        contentType
+      );
   }
 
   return magicPen.toString(MagicPen.defaultFormat);
@@ -80,10 +90,34 @@ module.exports = async (cwd, argv, console, getStdin, isTTY) => {
       demand: false,
       default: isTTY,
       type: 'boolean'
+    })
+    .option('unified-context', {
+      alias: ['U', 'C'],
+      demand: false,
+      default: 5,
+      type: 'number'
+    })
+    .option('before-context', {
+      alias: 'B',
+      demand: false,
+      type: 'number'
+    })
+    .option('after-context', {
+      alias: 'A',
+      demand: false,
+      type: 'number'
     }).argv;
 
   async function handleNonOptionArguments(cwd, argv) {
-    const { root, context, workspace, _: nonOptionArgs } = argv;
+    const {
+      root,
+      context,
+      workspace,
+      unifiedContext,
+      beforeContext = unifiedContext,
+      afterContext = unifiedContext,
+      _: nonOptionArgs
+    } = argv;
     const workspaceMappings = getWorkspaceMappings(workspace);
 
     for (let i = 0; i < nonOptionArgs.length; i += 1) {
@@ -153,7 +187,9 @@ module.exports = async (cwd, argv, console, getStdin, isTTY) => {
               sourceText,
               contentType,
               line,
-              column
+              column,
+              beforeContext,
+              afterContext
             })
           );
         }

--- a/test/main.js
+++ b/test/main.js
@@ -86,9 +86,86 @@ describe('main', function() {
             '\t\tif ( document.addEventListener ) {\n' +
             '                ^\n' +
             '\t\t\tdocument.removeEventListener( "DOMContentLoaded", completed, false );\n' +
-            '\t\t\twindow.removeEventListener( "load", completed, false );\n'
+            '\t\t\twindow.removeEventListener( "load", completed, false );\n' +
+            '\n' +
+            '\t\t} else {\n' +
+            '\t\t\tdocument.detachEvent( "onreadystatechange", completed );'
         ]
       );
+    });
+
+    describe('and -U', function() {
+      it('should render the specified number of context lines before and after', async function() {
+        await expect(
+          [
+            '--context',
+            '-U3',
+            'testdata/existingJavaScriptSourceMap/jquery-1.10.1.min.js',
+            '4',
+            '745'
+          ],
+          'to yield output',
+          [
+            'testdata/existingJavaScriptSourceMap/jquery-1.10.1.js:109:16',
+            '\t},\n' +
+              '\t// Clean-up method for dom ready events\n' +
+              '\tdetach = function() {\n' +
+              '\t\tif ( document.addEventListener ) {\n' +
+              '                ^\n' +
+              '\t\t\tdocument.removeEventListener( "DOMContentLoaded", completed, false );\n' +
+              '\t\t\twindow.removeEventListener( "load", completed, false );\n'
+          ]
+        );
+      });
+    });
+
+    describe('and -B and -A', function() {
+      it('should render the specified number of context lines before and after', async function() {
+        await expect(
+          [
+            '--context',
+            '-B1',
+            '-A2',
+            'testdata/existingJavaScriptSourceMap/jquery-1.10.1.min.js',
+            '4',
+            '745'
+          ],
+          'to yield output',
+          [
+            'testdata/existingJavaScriptSourceMap/jquery-1.10.1.js:109:16',
+            '\tdetach = function() {\n' +
+              '\t\tif ( document.addEventListener ) {\n' +
+              '                ^\n' +
+              '\t\t\tdocument.removeEventListener( "DOMContentLoaded", completed, false );\n' +
+              '\t\t\twindow.removeEventListener( "load", completed, false );'
+          ]
+        );
+      });
+
+      describe('and -U', function() {
+        it('should prefer the -A and -B values and ignore -U', async function() {
+          await expect(
+            [
+              '--context',
+              '-U10',
+              '-B1',
+              '-A2',
+              'testdata/existingJavaScriptSourceMap/jquery-1.10.1.min.js',
+              '4',
+              '745'
+            ],
+            'to yield output',
+            [
+              'testdata/existingJavaScriptSourceMap/jquery-1.10.1.js:109:16',
+              '\tdetach = function() {\n' +
+                '\t\tif ( document.addEventListener ) {\n' +
+                '                ^\n' +
+                '\t\t\tdocument.removeEventListener( "DOMContentLoaded", completed, false );\n' +
+                '\t\t\twindow.removeEventListener( "load", completed, false );'
+            ]
+          );
+        });
+      });
     });
   });
 


### PR DESCRIPTION
A superset of the options supported by `grep`, `diff`, `git-diff`, and `ag`. I think this makes us do the least surprising thing™ in most cases.

Since `--context` and `-c` is already a boolean option I left that alone, even though `grep --context=123` does the same as `grep -C123`. Would be nice to fix that as well, but that would be semver-major.

We could maybe special case `--context=123`. The `grep` docs say:

> ```
>     -C[num, --context=num]
>             Print num lines of leading and trailing context surrounding each match.  The default is 2 and is equivalent to -A 2 -B 2.  Note: no whitespace may be given between the
>             option and its argument.
> ```

But `yargs` makes that a bit hard for switches that have a type of `boolean`, so it didn't seem worth it. Also, `ag` permits space between `--context` and the number of lines. Hard to be compatible with everything at once 😅